### PR TITLE
Update license, participation, and CoC link

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -21,13 +21,21 @@ As of March 2025, CAWG is becoming a working group of the link:https://identity.
 
 === Governance
 
-Each of the projects of the Creator Assertion Working Group are licensed and governed under the link:https://github.com/CommunitySpecification/1.0[Community Specification License 1.0]. In order to contribute to the specifications or the working group meetings, you will first need to sign the contributor license agreement. The process for this is separate for each CAWG project and described in the README document for each repository.
+Each of the projects of the Creator Assertion Working Group are licensed and governed under the link:http://www.w3.org/Consortium/Patent-Policy-20040205[W3C Patent Policy]. In order to contribute to the specifications or the working group meetings, you will first need to sign the appropriate agreement:
+
+- **If you're already a DIF Member**, no further steps needed
+- **If you're an Unaffiliated Individual**: Sign the link:https://bit.ly/DIF-feedback-agreement[DIF Feedback Agreement] and select "Creator Assertions" WG
+- **If you're not a DIF Member, participating on behalf of an Organization**:
+    - If you'd like to join DIF, link:https://identity.foundation/join/[start here] or contact us at membership@identity.foundation
+    - If you're a member of ToIP or have previously signed the CAWG CLA (see section 3 in the link:https://github.com/decentralized-identity/org/blob/main/Org%20documents/WG%20documents/DIF_CAWG_WG_Operating_Addendum_v1.pdf[Operating Addendum] for the latest list of organizations):
+        - Sign the link:https://bit.ly/DIF-contributor[DIF Contributor Agreement]
+    - If you have questions, email membership@identity.foundation
 
 Each project contains a scope document (see `scope.md` at the root of each repository) which describes the intended purpose of the project.
 
 === Code of conduct
 
-Each of the projects of the Creator Assertions Working Group are covered by a code of conduct adapted from the link:https://www.contributor-covenant.org[Contributor Covenant Code of Conduct]. This code of conduct describes standards for acceptable and unacceptable behavior and policies for enforcing those standards. As an example, see the link:https://github.com/creator-assertions/identity-assertion/blob/main/code-of-conduct.md[Code of Conduct] in the Identity Assertion project. All projects follow this same code of conduct.
+We are committed to providing a welcoming and inspiring community for all. Please read and understand link:https://github.com/decentralized-identity/org/blob/master/code-of-conduct.md[DIF's Code of Conduct] before participating in this project.
 
 === Meeting schedule
 


### PR DESCRIPTION
Update to DIF versions of CoC, license agreement, and detail participation options.

Feel free to tweak.